### PR TITLE
Update README for macOS high sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Simply connect with a telnet client of your choosing. By default, the server use
 Navigate to the terminal, and type
 
     telnet <ip address> 1234
+		
+#### On MacOS High Sierra and higher
+
+Navigate to the terminal, and type
+
+    nc <ip address> 1234
 
 #### On Windows:
 


### PR DESCRIPTION
Update README to show how to connect to the server on macOS high sierra, since apple removed telnet.